### PR TITLE
Expand buckets and prefill balls

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <input id="colorInput" type="color" value="#f94144" />
     </label>
     <label>Angle
-      <input id="angleInput" type="range" min="10" max="80" value="45" />
+      <input id="angleInput" type="range" min="10" max="170" value="135" />
     </label>
     <label>Power
       <input id="powerInput" type="range" min="0" max="100" value="60" />


### PR DESCRIPTION
## Summary
- Enlarge left and right buckets for 250 and 500 ball capacities respectively
- Preload both buckets with mixed-color balls and label the left bucket "2024"
- Allow wider cannon angle range so shots can reach the large bucket

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af86ac3048331b9bdacc9d5b0e3d3