### PR TITLE
Improve cannon controls, add player and color selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,22 @@
       <input id="ballsInput" type="number" min="1" max="200" value="4" />
     </label>
     <label>Color
-      <input id="colorInput" type="color" value="#f94144" />
+      <select id="colorInput">
+        <option value="red" selected>Red</option>
+        <option value="blue">Blue</option>
+        <option value="yellow">Yellow</option>
+        <option value="green">Green</option>
+        <option value="orange">Orange</option>
+      </select>
+    </label>
+    <label>Player
+      <select id="playerSelect">
+        <option value="player1" selected>Player 1</option>
+        <option value="player2">Player 2</option>
+      </select>
     </label>
     <label>Angle
-      <input id="angleInput" type="range" min="10" max="170" value="135" />
+      <input id="angleInput" type="range" min="10" max="170" value="45" />
     </label>
     <label>Power
       <input id="powerInput" type="range" min="0" max="100" value="60" />


### PR DESCRIPTION
## Summary
- Space out and shrink buckets for better play area
- Allow choosing ball color and player avatar before firing
- Reverse angle controls and show current angle and power under cannon

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689b156bf6a8833181cb2dd7f9a01b8e