### PR TITLE
Shrink bucket, reposition controls, add sky

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
 </head>
 <body>
   <h1 id="title">ASTRA 500</h1>
+  <div id="stage">
+    <canvas id="game" width="1024" height="576"></canvas>
+  </div>
   <aside id="menu">
     <label># Balls
       <input id="ballsInput" type="number" min="1" max="200" value="4" />
@@ -51,9 +54,6 @@
       <button id="deleteBtn">DELETE</button>
     </label>
   </aside>
-  <div id="stage">
-    <canvas id="game" width="1024" height="576"></canvas>
-  </div>
   <div id="stats">
     <div id="leftStats"></div>
     <div id="rightStats"></div>

--- a/style.css
+++ b/style.css
@@ -1,21 +1,25 @@
 body {
   margin: 0;
   display: flex;
+  flex-direction: column;
+  align-items: center;
   font-family: 'Press Start 2P', monospace;
-  background: #001f3f;
+  background: #87ceeb;
   color: #fff;
   position: relative;
 }
 
 #menu {
-  width: 220px;
-  background: #ccc;
-  color: #000;
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
   padding: 10px;
   box-sizing: border-box;
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 10px;
+  margin-top: 10px;
+  border: 4px solid #000;
 }
 
 #menu label {
@@ -31,7 +35,8 @@ button {
   padding: 8px;
   cursor: pointer;
   background: #fff;
-  border: 2px solid #000;
+  border: 4px solid #000;
+  box-shadow: 2px 2px 0 #000;
 }
 
 button:focus {
@@ -79,10 +84,11 @@ button:focus {
 }
 
 #stage {
-  flex: 1;
   position: relative;
   aspect-ratio: 16 / 9;
   image-rendering: pixelated;
+  width: 100%;
+  max-width: 1024px;
 }
 
 #game {


### PR DESCRIPTION
## Summary
- Reduce left bucket size by about 25% while keeping initial ball counts
- Move cannon controls below playfield with retro-styled buttons
- Fire cannon with the spacebar only and add moving cloud backdrop

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689b3041f7a08331a0588f6cbf1559d3